### PR TITLE
Adding retry logging and ACI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,192 @@ Thumbs.db
 
 # config files
 *.ini
+
+# Common python ignores
+Skip to content
+Search or jump to…
+Pull requests
+Issues
+Marketplace
+Explore
+ 
+@cherrera2001 
+Branch master was renamed to main.
+github
+/
+gitignore
+Public
+Code
+Pull requests
+240
+Actions
+Security
+Insights
+gitignore/Python.gitignore
+@Wiblz
+Wiblz Replace references of this repo's "master" branch
+…
+Latest commit 093b0fb 4 days ago
+ History
+ 85 contributors
+@arcresu@shiftkey@Lucretiel@Harrison-G@jwg4@GabrielC101@misaelnieto@pmsosa@svkampen@vltr@thedrow@matheussl
+145 lines (118 sloc)  2.36 KB
+   
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+© 2021 GitHub, Inc.
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About
+

--- a/seeq/addons/azureml/backend/_aml_online_endpoint_service.py
+++ b/seeq/addons/azureml/backend/_aml_online_endpoint_service.py
@@ -33,7 +33,7 @@ class AmlOnlineEndpointService:
         retry_strategy = Retry(
             total=3,
             status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=["POST", "GET"]
+            allowed_methods=["POST", "GET"]
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self._http = requests.Session()

--- a/seeq/addons/azureml/backend/_aml_online_endpoint_service.py
+++ b/seeq/addons/azureml/backend/_aml_online_endpoint_service.py
@@ -2,7 +2,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
 from datetime import datetime, timedelta
-from ._aml_response_models import OnlineDeployment, OnlineEndpoint, AmlModel, AmlWorkspaceDetails
+from ._aml_response_models import OnlineDeployment, OnlineEndpoint, AmlModel
 from seeq.addons.azureml.utils import AzureMLException
 
 API_VERSION = "2021-03-01-preview"
@@ -37,8 +37,6 @@ class AmlOnlineEndpointService:
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self._http = requests.Session()
-        self._http.mount("https://", adapter)
-        self._http.mount("http://", adapter)
 
     def _authorize(self):
 

--- a/seeq/addons/azureml/backend/_aml_online_endpoint_service.py
+++ b/seeq/addons/azureml/backend/_aml_online_endpoint_service.py
@@ -1,10 +1,15 @@
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util import Retry
 from datetime import datetime, timedelta
-from ._aml_response_models import OnlineDeployment, OnlineEndpoint, AmlModel
-from seeq.addons.azureml.utils import AzureMLException
+from ._aml_response_models import OnlineDeployment, OnlineEndpoint, AmlModel, AmlWorkspaceDetails
+from _exceptions import AzureMLException
 
+API_VERSION = "2021-03-01-preview"
 
 class AmlOnlineEndpointService:
+
+    
     """
     Provides a service to connect to Azure ML Studio and get endpoints that are
     tagged with `{Seeq: true}` and their associated deployments and models.
@@ -25,6 +30,15 @@ class AmlOnlineEndpointService:
         self._workspace_name = workspace_name
         self._token = None
         self._token_expires_on = None
+        retry_strategy = Retry(
+            total=3,
+            status_forcelist=[429, 500, 502, 503, 504],
+            method_whitelist=["POST", "GET"]
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self._http = requests.Session()
+        self._http.mount("https://", adapter)
+        self._http.mount("http://", adapter)
 
     def _authorize(self):
 
@@ -48,7 +62,7 @@ class AmlOnlineEndpointService:
                   f"core.windows.net%2F&client_id={self._app_id}"
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
-        response = requests.post(url, headers=headers, data=payload)
+        response = self._http.post(url, headers=headers, data=payload)
 
         if response.status_code != 200:
             raise AzureMLException(code=response.status_code, reason=response.reason, message="Azure Login Failed")
@@ -73,6 +87,38 @@ class AmlOnlineEndpointService:
         headers = {'Authorization': f'Bearer {self._authorize()}'}
         return url, headers
 
+    def _get_regional_model_mgmt_url(self):
+        """
+        Private method to get the region management URL
+
+        Returns
+        -------
+        url, headers: tuple (str, str)
+            URL and headers of the management service
+
+        """
+
+        url_base, headers = self._get_base_mgmt_url()
+        url = f"{url_base}?api-version={API_VERSION}"
+        headers = {'Authorization': f'Bearer {self._authorize()}'}
+        
+        response = self._http.get(url, headers=headers)
+        if response.status_code != 200:
+            raise AzureMLException(code=response.status_code, reason=response.reason, message="Error getting workspace details")
+
+        workspaceDetails = AmlWorkspaceDetails.deserialize_aml_workspace_response(response.json())
+
+        response = self._http.get(workspaceDetails.discovery_url)
+        if response.status_code != 200:
+            raise AzureMLException(code=response.status_code, reason=response.reason, message="Error accessing workspace discovery")
+        
+        mgmt_url =  f"{response.json()['modelmanagement']}/modelmanagement/v1.0/subscriptions/{self._subscription_id}/resourceGroups/" \
+            f"{self._resource_group}/providers/Microsoft.MachineLearningServices/workspaces/{self._workspace_name}/services/"
+        mgmt_headers = {'Authorization': f'Bearer {self._authorize()}'}
+
+        return mgmt_url, mgmt_headers
+        
+
     def _get_models(self, deployment: OnlineDeployment):
         """
         Private method to get models associated with a given deployment
@@ -91,7 +137,7 @@ class AmlOnlineEndpointService:
         url = f"https://ml.azure.com/api/{deployment.location}/modelmanagement/v1.0{path}"
         headers = {'Authorization': f'Bearer {self._authorize()}'}
 
-        response = requests.get(url, headers=headers)
+        response = self._http.get(url, headers=headers)
         if response.status_code != 200:
             raise AzureMLException(code=response.status_code, reason=response.reason, message="Error getting models")
 
@@ -115,13 +161,13 @@ class AmlOnlineEndpointService:
 
         url_base, headers = self._get_base_mgmt_url()
 
-        url = f"{url_base}onlineEndpoints/{endpoint.name}/deployments?api-version=2021-03-01-preview"
-        response = requests.get(url, headers=headers)
+        url = f"{url_base}onlineEndpoints/{endpoint.name}/deployments?api-version={API_VERSION}"
+        response = self._http.get(url, headers=headers)
         if response.status_code != 200:
             raise AzureMLException(code=response.status_code, reason=response.reason,
                                    message="Error getting deployments")
 
-        deployments = OnlineDeployment.deserialize_aml_deployment_response(response.json())
+        deployments = OnlineDeployment.deserialize_aml_deployment_response(response.json(), "Managed")
 
         for d in deployments:
             self._get_models(d)
@@ -142,19 +188,52 @@ class AmlOnlineEndpointService:
         -: None
 
         """
+        url = ""
+        headers = {}
 
-        base_url, headers = self._get_base_mgmt_url()
+        if endpoint.kind == "Managed":
+            base_url, headers = self._get_base_mgmt_url()
+            url = f"{base_url}onlineEndpoints/{endpoint.name}/listKeys?api-version={API_VERSION}"
+        else:
+            base_url, headers = self._get_regional_model_mgmt_url()
+            url = f"{base_url}{endpoint.name}/listKeys"
 
-        url = f"{base_url}onlineEndpoints/{endpoint.name}/listKeys?api-version=2021-03-01-preview"
-
-        response = requests.post(url, headers=headers)
+        response = self._http.post(url, headers=headers)
 
         if response.status_code != 200:
             raise AzureMLException(code=response.status_code, reason=response.reason,
-                                   message=f"Error listing keys for endpoint. Endpoint name: {endpoint.name}")
+                                message=f"Error listing keys for endpoint. Endpoint name: {endpoint.name}")
         keys = response.json()
         endpoint.primaryKey = keys['primaryKey']
         endpoint.secondaryKey = keys['secondaryKey']
+
+    def _get_aci_online_endpoints(self):
+        """
+        Private method to get a list of endpoints that are deployed as an ACI
+        compute type. This is a workaround due to the endpoints API not returing
+        endpoints that have a compute type of ACI.
+
+        Returns
+        -------
+        oes: list
+            List of OnlineEndpoint objects with deployments and models attached 
+            to each object
+        """
+        url, headers = self._get_regional_model_mgmt_url()
+        headers['computeType'] = "ACI"
+        response = self._http.get(url, headers=headers)
+
+        if response.status_code != 200:
+            raise AzureMLException(code=response.status_code, reason=response.reason, message="Error getting ACI endpoints")
+
+        oes = OnlineEndpoint.deserialize_aml_services_response(response.json())
+        for oe in oes:
+            self._add_keys_to_endpoint(oe)
+            # unmanaged endpoints only have one deployment
+            oe.deployment[0].modelId = f"/subscriptions/{self._subscription_id}/resourceGroups/{self._resource_group}/" \
+                f"providers/Microsoft.MachineLearningServices/workspaces/{self._workspace_name}/models/{oe.deployment[0].model}/versions/{oe.deployment[0].model_version}"
+            self._get_models(oe.deployment[0])
+        return oes
 
     def _get_online_endpoints(self):
         """
@@ -170,7 +249,7 @@ class AmlOnlineEndpointService:
         """
         url_base, headers = self._get_base_mgmt_url()
         url = f"{url_base}onlineEndpoints?api-version=2021-03-01-preview"
-        response = requests.get(url, headers=headers)
+        response = self._http.get(url, headers=headers)
 
         if response.status_code != 200:
             raise AzureMLException(code=response.status_code, reason=response.reason, message="Error getting endpoints")
@@ -193,8 +272,9 @@ class AmlOnlineEndpointService:
             List of OnlineEndpoint objects with deployments and models attached
             to each object
         """
-        return self._get_online_endpoints()
-
+        oes = self._get_aci_online_endpoints()
+        oes += self._get_online_endpoints()
+        return oes
 
 def exception_message(message, code, reason):
     return f'{message}. Return code: {str(code)} with reason: {str(reason)}'

--- a/seeq/addons/azureml/backend/_aml_response_models.py
+++ b/seeq/addons/azureml/backend/_aml_response_models.py
@@ -90,6 +90,7 @@ class AmlModel:
             model.sample_rate = tags.get('SampleRate', )
         return model
 
+
 class OnlineDeployment:
     """
     Gets the serialized response from the Azure ML deployments endpoint and
@@ -122,7 +123,7 @@ class OnlineDeployment:
         ----------
         name : str
             Name of the Azure ML deployment
-        idd : str
+        idd : str or None
             ID of the Azure ML deployment
         """
         self.id = idd

--- a/seeq/addons/azureml/backend/_aml_response_models.py
+++ b/seeq/addons/azureml/backend/_aml_response_models.py
@@ -241,7 +241,7 @@ class OnlineEndpoint:
         self.secondaryKey = None
 
     @staticmethod
-    def deserialize_aml_services_response(json):
+    def deserialize_unmanaged_endpoint_response(json):
         """
         Deserializes the Azure ML response services response for ACI models
 
@@ -281,7 +281,7 @@ class OnlineEndpoint:
 
 
     @staticmethod
-    def deserialize_aml_endpoint_response(json):
+    def deserialize_managed_endpoint_response(json):
         """
         Deserializes the Azure ML response from the online endpoints endpoint
 

--- a/seeq/addons/azureml/backend/_aml_response_models.py
+++ b/seeq/addons/azureml/backend/_aml_response_models.py
@@ -206,8 +206,11 @@ class OnlineEndpoint:
 
     Methods
     -------
-    deserialize_aml_endpoint_response(json)
-        Deserializes the Azure ML response from the online endpoints endpoint
+    deserialize_unmanaged_endpoint_response(json)
+        Deserializes the Azure ML response from the unmanaged online endpoints endpoint
+
+    deserialize_managed_endpoint_response
+        Deserializes the Azure ML response from the managed online endpoints endpoint
 
     add_deployment(seeq.addons.azureml.backend.OnlineDeployment)
         Adds an OnlineDeployment to the endpoint only if the traffic split

--- a/seeq/addons/azureml/backend/_aml_response_models.py
+++ b/seeq/addons/azureml/backend/_aml_response_models.py
@@ -90,47 +90,6 @@ class AmlModel:
             model.sample_rate = tags.get('SampleRate', )
         return model
 
-class AmlWorkspaceDetails:
-    """
-    Gets the serialized respoonse from the Azure ML workspace endpoint and 
-    deserailizes it
-    """
-
-    def __init__(self, region, discovery_url) -> None:
-        """
-        Parameters
-        ----------
-        region : str
-            Name of the region where the Azure ML workspace is located
-        discovery_url : str
-            URL for Azure ML regional API server locations
-        """
-        self.region = region
-        self.discovery_url = discovery_url
-        self.name = None
-    
-    @staticmethod
-    def deserialize_aml_workspace_response(json):
-        """
-        Gets a serialized response from a given workspace description in Azure ML and
-        deserializes it
-
-        Parameters
-        ----------
-        json: dict
-            Serialized response of the Azure ML deployment endpoint
-
-        Returns
-        -------
-        ods: list
-            List of deployments associated with the endpoint
-
-        """
-        workspaceDetails = AmlWorkspaceDetails(region=json['location'], discovery_url=json['properties']['discoveryUrl'])
-        workspaceDetails.name = json['properties']['friendlyName']
-        return workspaceDetails
-
-
 class OnlineDeployment:
     """
     Gets the serialized response from the Azure ML deployments endpoint and


### PR DESCRIPTION
This PR adds a retry strategy to all recoverable HTTP errors. Additionally, it adds support for ACI instances after a change by MSFT on how they expose unmanaged endpoints.

This PR resolves #6  